### PR TITLE
mwgc: bind() returns 0 on success and -1 on failure

### DIFF
--- a/src/mavlink/mwgc.c
+++ b/src/mavlink/mwgc.c
@@ -155,8 +155,8 @@ int main(int argc, char* argv[])
     locAddr.sin_port = htons(14551);
 
     /* Bind the socket to port 14551 - necessary to receive packets from qgroundcontrol */
-    if (NOK == bind(sock, (struct sockaddr *)&locAddr, sizeof(struct sockaddr))) {
-        perror("error bind failed");
+    if (NOK != bind(sock, (struct sockaddr *)&locAddr, sizeof(struct sockaddr))) {
+        perror("error bind to port 14551 failed");
         eexit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Don't error out on success.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
