### PR TITLE
GPS support

### DIFF
--- a/src/mavlink/mwgc.c
+++ b/src/mavlink/mwgc.c
@@ -367,13 +367,13 @@ void callBack_mwi(int state)
 
         case MSP_RAW_GPS:
             /* Send gps */
-            mavlink_msg_gps_raw_int_pack(mwiUavID, 200, &msg, currentTime, mwiState->GPS_fix + 1, mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude*10.0, 0, 0, mwiState->GPS_speed, mwiState->GPS_numSat, 0);
+            mavlink_msg_gps_raw_int_pack(mwiUavID, 200, &msg, currentTime, mwiState->GPS_fix + 1, mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude*1000.0, 0, 0, mwiState->GPS_speed, mwiState->GPS_numSat, 0);
             len = mavlink_msg_to_send_buffer(buf, &msg);
             sendto(sock, buf, len, 0, (struct sockaddr*)&groundStationAddr, sizeof(struct sockaddr_in));
 
 
             mavlink_msg_global_position_int_pack(mwiUavID, 200, &msg, currentTime,
-                    mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude*10.0, mwiState->baro, 0,0,0, mwiState->GPS_heading);
+                    mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude*10.0, mwiState->baro, 0,0,0,0);
             len = mavlink_msg_to_send_buffer(buf, &msg);
             sendto(sock, buf, len, 0, (struct sockaddr*)&groundStationAddr, sizeof(struct sockaddr_in));
 

--- a/src/mwi/mwi.c
+++ b/src/mwi/mwi.c
@@ -195,9 +195,8 @@ void decode(mwi_uav_state_t *mwiState)
             mwiState->GPS_numSat = read8();
             mwiState->GPS_latitude = read32();
             mwiState->GPS_longitude = read32();
-            mwiState->GPS_altitude = (uint16_t)readu16();
-            mwiState->GPS_speed = read16();
-            mwiState->GPS_heading = read16();
+            mwiState->GPS_altitude = read16();
+            mwiState->GPS_speed = (uint16_t)readu16();
             /* Send gps */
             break;
 


### PR DESCRIPTION
I tried to implement GPS support, but as stated in the commit message for log2cvs the lat/lon values are bogus. I suspect I screwed up the read32() function but an endiannes conversion bug might also be to blame.

When using this with qgroundcontrol altitude flops around between 10m and -540m, but log2cvs reports a stead '827', so that is likely a multiwii bug.

So this isn't really fit for merging yet, but I wanted to get it out there so more people can look at it.
