### PR TITLE
mwi: really fix read32()

### DIFF
--- a/src/mwi/mwi.c
+++ b/src/mwi/mwi.c
@@ -94,9 +94,9 @@ void setState(int aState)
 int read32(void)
 {
     int32_t t = frame[readindex++] & 0xff;
-    t += frame[readindex++] << 8;
-    t += frame[readindex++] << 16;
-    t += frame[readindex] << 24;
+    t += (frame[readindex++] & 0xff) << 8;
+    t += (frame[readindex++] & 0xff) << 16;
+    t += (frame[readindex++] & 0xff) << 24;
     return t;
 
 }


### PR DESCRIPTION
I compared the read32() function with the one in MultiWii conf and noticed a missing index increment.

This makes GPS work!

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
