### PR TITLE
mwgc: fix mavlink_msg_gps_raw_int_pack usage

### DIFF
--- a/src/mavlink/mwgc.c
+++ b/src/mavlink/mwgc.c
@@ -398,7 +398,7 @@ void callBack_mwi(int state)
 
         case MSP_RAW_GPS:
             // Send gps
-            mavlink_msg_gps_raw_int_pack(mwiUavID, 200, &msg, currentTime, mwiState->GPS_fix + 1, mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude * 1000.0, 0, 0, mwiState->GPS_speed, mwiState->GPS_numSat, 0);
+            mavlink_msg_gps_raw_int_pack(mwiUavID, 200, &msg, currentTime, mwiState->GPS_fix + 1, mwiState->GPS_latitude, mwiState->GPS_longitude, mwiState->GPS_altitude * 1000.0, 0, 0, mwiState->GPS_speed, 0, mwiState->GPS_numSat);
             len = (char)mavlink_msg_to_send_buffer(buf, &msg);
             sendto(sock, (const char *)buf, (char)len, 0, (struct sockaddr*)&groundStationAddr, sizeGroundStationAddr);
 


### PR DESCRIPTION
mavlink_msg_gps_raw_int_pack is defined as:

static inline uint16_t mavlink_msg_gps_raw_int_pack(uint8_t system_id,
        uint8_t component_id, mavlink_message_t\* msg, uint64_t time_usec,
        uint8_t fix_type, int32_t lat, int32_t lon, int32_t alt, uint16_t eph,
        uint16_t epv, uint16_t vel, uint16_t cog, uint8_t satellites_visible) {

Swap Course-Over-Ground and visible satelites

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
