### PR TITLE
mwgc: fix battery voltage conversion

### DIFF
--- a/src/mavlink/mwgc.c
+++ b/src/mavlink/mwgc.c
@@ -402,7 +402,7 @@ void callBack_mwi(int state)
             // all present sensors enabled by default except altitude and position control which we will set individually
             sensors = sensors & (~MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL & ~MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL);
 
-            mavlink_msg_sys_status_pack(mwiUavID, MAV_COMP_ID_ALL, &msg, sensors, sensors, 0, (mwiState->cycleTime / 10), mwiState->vBat * 1000, mwiState->pAmp, mwiState->pMeterSum, mwiState->rssi, mwiState->i2cError, mwiState->debug[0], mwiState->debug[1], mwiState->debug[2],
+            mavlink_msg_sys_status_pack(mwiUavID, MAV_COMP_ID_ALL, &msg, sensors, sensors, 0, (mwiState->cycleTime / 10), mwiState->vBat * 100, mwiState->pAmp, mwiState->pMeterSum, mwiState->rssi, mwiState->i2cError, mwiState->debug[0], mwiState->debug[1], mwiState->debug[2],
                     mwiState->debug[3]);
 
             len = (char)mavlink_msg_to_send_buffer(buf, &msg);


### PR DESCRIPTION
MultiWii types.h says:

typedef struct {
  uint8_t  vbat;               // battery voltage in 0.1V steps
  uint16_t intPowerMeterSum;
  uint16_t rssi;              // range: [0;1023]
  uint16_t amperage;
} analog_t;

Which is deciVolt instead of Volt.

Mavlink has:

  voltage_battery   uint16_t    Battery voltage, in millivolts (1 = 1 millivolt)

So multiply by 100 instead of 1000. Compile tested only.

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
